### PR TITLE
Fix GcrRegion#getRegion(String)

### DIFF
--- a/src/main/java/com/distelli/gcr/GcrRegion.java
+++ b/src/main/java/com/distelli/gcr/GcrRegion.java
@@ -8,6 +8,8 @@
 */
 package com.distelli.gcr;
 
+import java.util.Arrays;
+
 public enum GcrRegion
 {
     DEFAULT("gcr.io"),
@@ -32,13 +34,11 @@ public enum GcrRegion
         return String.format("https://%s", _endpoint);
     }
 
-    public static GcrRegion getRegion(String region)
+    public static GcrRegion getRegion(String endpoint)
     {
-        try {
-            GcrRegion gcrRegion = GcrRegion.valueOf(region.toUpperCase());
-            return gcrRegion;
-        } catch(IllegalArgumentException iae) {
-            return null;
-        }
+        return Arrays.stream(values())
+            .filter((region) -> region._endpoint.equalsIgnoreCase(endpoint))
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/src/test/java/com/distelli/gcr/TestGcrRegion.java
+++ b/src/test/java/com/distelli/gcr/TestGcrRegion.java
@@ -1,0 +1,27 @@
+package com.distelli.gcr;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class TestGcrRegion {
+    @Test
+    public void testGetRegion() {
+        GcrRegion defaultRegion = GcrRegion.getRegion("gcr.io");
+        assertThat(defaultRegion, equalTo(GcrRegion.DEFAULT));
+
+        GcrRegion usRegion = GcrRegion.getRegion("us.gcr.io");
+        assertThat(usRegion, equalTo(GcrRegion.US));
+
+        GcrRegion euRegion = GcrRegion.getRegion("eu.gcr.io");
+        assertThat(euRegion, equalTo(GcrRegion.EU));
+
+        GcrRegion asiaRegion = GcrRegion.getRegion("asia.gcr.io");
+        assertThat(asiaRegion, equalTo(GcrRegion.ASIA));
+
+        GcrRegion fakeRegion = GcrRegion.getRegion("fake.example.com");
+        assertThat(fakeRegion, nullValue());
+    }
+}


### PR DESCRIPTION
This modifies `GcrRegion#getRegion(String)` to take the region endpoint and
return the region, rather than taking the string equivalent of the region and
returning the region object. Based on the only way this method is used, that
was the expected behavior (and seems more useful), but not what it actually did.