### PR TITLE
Add GcrRegion#getRegionByEndpoint(String)

### DIFF
--- a/src/main/java/com/distelli/gcr/GcrRegion.java
+++ b/src/main/java/com/distelli/gcr/GcrRegion.java
@@ -8,6 +8,8 @@
 */
 package com.distelli.gcr;
 
+import java.util.Arrays;
+
 public enum GcrRegion
 {
     DEFAULT("gcr.io"),
@@ -32,6 +34,26 @@ public enum GcrRegion
         return String.format("https://%s", _endpoint);
     }
 
+    /**
+     * Get the GcrRegion corresponding to the provided endpoint.
+     *
+     * @param endpoint the endpoint for the region, such as {@code "us.gcr.io"} or {@code "eu.gcr.io"}
+     * @return the GcrRegion, or null if no such region exists
+     */
+    public static GcrRegion getRegionByEndpoint(String endpoint)
+    {
+        return Arrays.stream(values())
+            .filter((region) -> region._endpoint.equalsIgnoreCase(endpoint))
+            .findFirst()
+            .orElse(null);
+    }
+
+    /**
+     * Get the GcrRegion corresponding to the associated short name.
+     *
+     * @param region the short name for the region, such as {@code "us"} or {@code "eu"}
+     * @return the GcrRegion, or null if no such region exists
+     */
     public static GcrRegion getRegion(String region)
     {
         try {

--- a/src/test/java/com/distelli/gcr/TestGcrRegion.java
+++ b/src/test/java/com/distelli/gcr/TestGcrRegion.java
@@ -1,0 +1,45 @@
+package com.distelli.gcr;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class TestGcrRegion {
+    @Test
+    public void testGetRegion() {
+        GcrRegion defaultRegion = GcrRegion.getRegion("default");
+        assertThat(defaultRegion, equalTo(GcrRegion.DEFAULT));
+
+        GcrRegion usRegion = GcrRegion.getRegion("us");
+        assertThat(usRegion, equalTo(GcrRegion.US));
+
+        GcrRegion euRegion = GcrRegion.getRegion("eu");
+        assertThat(euRegion, equalTo(GcrRegion.EU));
+
+        GcrRegion asiaRegion = GcrRegion.getRegion("asia");
+        assertThat(asiaRegion, equalTo(GcrRegion.ASIA));
+
+        GcrRegion fakeRegion = GcrRegion.getRegion("fake");
+        assertThat(fakeRegion, nullValue());
+    }
+
+    @Test
+    public void testGetRegionByEndpoint() {
+        GcrRegion defaultRegion = GcrRegion.getRegionByEndpoint("gcr.io");
+        assertThat(defaultRegion, equalTo(GcrRegion.DEFAULT));
+
+        GcrRegion usRegion = GcrRegion.getRegionByEndpoint("us.gcr.io");
+        assertThat(usRegion, equalTo(GcrRegion.US));
+
+        GcrRegion euRegion = GcrRegion.getRegionByEndpoint("eu.gcr.io");
+        assertThat(euRegion, equalTo(GcrRegion.EU));
+
+        GcrRegion asiaRegion = GcrRegion.getRegionByEndpoint("asia.gcr.io");
+        assertThat(asiaRegion, equalTo(GcrRegion.ASIA));
+
+        GcrRegion fakeRegion = GcrRegion.getRegionByEndpoint("fake.example.com");
+        assertThat(fakeRegion, nullValue());
+    }
+}


### PR DESCRIPTION
This adds a new method, `GcrRegion#getRegionByEndpoint(String)`, which allows
you to get a `GcrRegion` object based on a provided endpoint string.